### PR TITLE
Properly handle empty strings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -116,6 +116,9 @@ class UrlSlug {
     } = parseOptions(options)
 
     const fragments = unidecode(String(string)).match(NORMALIZE)
+    if (!fragments) {
+        return ''
+    }
 
     return transformer
       ? transformer(fragments, separator)

--- a/src/index.js
+++ b/src/index.js
@@ -117,7 +117,7 @@ class UrlSlug {
 
     const fragments = unidecode(String(string)).match(NORMALIZE)
     if (!fragments) {
-        return ''
+      return ''
     }
 
     return transformer
@@ -142,6 +142,10 @@ class UrlSlug {
       fragments = slug.split(separator)
     } else {
       fragments = slug.match(REVERT_UNKNOWN)
+    }
+
+    if (!fragments) {
+      return ''
     }
 
     return transformer ? transformer(fragments, ' ') : fragments.join(' ')

--- a/test/index.js
+++ b/test/index.js
@@ -208,6 +208,11 @@ describe('module', () => {
           .to.be.equal('Comfortably Numb')
       })
 
+      it('should empty strings revert to another empty string', () => {
+        expect(instance.revert(''))
+          .to.be.equal('')
+      })
+
     })
 
   })

--- a/test/index.js
+++ b/test/index.js
@@ -172,6 +172,15 @@ describe('module', () => {
           .to.be.equal('Rct')
       })
 
+      it('should handle empty strings', () => {
+        expect(instance.convert(''))
+          .to.be.equal('')
+      })
+
+      it('should handle strings with no alphanumeric characters', () => {
+        expect(instance.convert('- ( ) [ ]'))
+          .to.be.equal('')
+      })
     })
 
     describe('revert', () => {


### PR DESCRIPTION
Hey! I had some trouble with empty strings and strings with only symbols like ( ) etc. This is a pretty simple fix that will simply return an empty strings if there are no fragments. I also added some test cases.

Changes:
- changed convert() to return an empty string if there are no fragments.
- added test case for converting empty strings
- added test case for converting a string with only symbols
- changed revert() to return an empty string if there are no fragments.
- added test case for reverting empty strings