### PR TITLE
Add TypeScript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,25 @@
+declare type Transformer = (fragments: string[], separator: string) => string;
+declare type Options = {
+  camelCase?: boolean;
+  separator?: string;
+  transformer?: false | Transformer;
+};
+/**
+ * Builtin transformers
+ */
+export declare const LOWERCASE_TRANSFORMER: (fragments: string[], separator: string) => string;
+export declare const SENTENCECASE_TRANSFORMER: (fragments: string[], separator: string) => string;
+export declare const TITLECASE_TRANSFORMER: (fragments: string[], separator: string) => string;
+export declare const UPPERCASE_TRANSFORMER: (fragments: string[], separator: string) => string;
+/**
+ * Converts a string into a slug
+ */
+export declare function convert(string: string, options?: Options): string;
+/**
+ * Reverts a slug back to a string
+ */
+export declare function revert(slug: string, options?: Options): string;
+/**
+ * Sets convert() as the default export
+ */
+export default convert;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.0-beta.0",
   "description": "RFC 3986 compliant slug generator with multiple language support",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "build": "./node_modules/.bin/babel src --out-dir .",
     "prepare": "cross-env NODE_ENV=production npm run build",


### PR DESCRIPTION
Created by converting the existing code to TypeScript and copying the resulting types declaration file (let me know if submitting another PR with the refactored TypeScript code replacing the JavaScript one would be desirable).

Without types, when adding `url-slug` to a TypeScript project, we get:

```
error TS7016: Could not find a declaration file for module 'url-slug'. '.../node_modules/url-slug/index.js' implicitly has an 'any' type.
  Try `npm install @types/url-slug` if it exists or add a new declaration (.d.ts) file containing `declare module 'url-slug';`

1 import urlSlug from 'url-slug';
                      ~~~~~~~~~~
```

By adding these types, that error is fixed and we get to have the benefits of typed functions.

For instance, I was doing `urlSlug(name)`, but `name` could be undefined, so the compiler warned me about it and I changed it to `urlSlug(name || '')`. Without the compiler warning, the previous code would have generated the slug `'undefined'`, which would have been undesirable.

### How to test
```sh
$ mkdir test-typings
$ cd test-typings
$ npm init
$ npm i typescript ts-node url-slug
$ tsc --init
$ echo "import urlSlug from 'url-slug';\nconsole.log(urlSlug('Hello World'));" > index.ts
$ ts-node index.ts
error TS7016
$ cp path-to-this-branch/index.d.ts node_nodes/url-slug
$ cp path-to-this-branch/package.json node_modules/url-slug
$ ts-node index.ts
hello-world
```

Closes https://github.com/stldo/url-slug/issues/10.